### PR TITLE
Add command line options for sguil-db-purge

### DIFF
--- a/bin/sguil-db-purge
+++ b/bin/sguil-db-purge
@@ -57,36 +57,6 @@ Security Onion: Database Event Purge Script
 Usage: $0
 EOF
 }
-while getopts "k:r:u:h" OPTION
-do
-     case $OPTION in
-	 h)
-		usage
-		exit 0
-	     ;;
-	 k)
-		OPT=1
-		DAYSTOKEEP=$OPTARG
-		if ! [ $DAYSTOKEEP -ge 1 ]; then
-                        echo "Not an integer greater than zero...exiting." && exit 1
-                fi
-	     ;;
-	 r)
-		OPT=1
-		DAYSTOREPAIR=$OPTARG
-		if ! [ $DAYSTOREPAIR -ge 1 ]; then
-			echo "Not an integer greater than zero...exiting." && exit 1
-		fi
-	     ;;
-	 u)
-		OPT=1
-		UNCAT_MAX=$OPTARG
-		if ! [ $UNCAT_MAX -ge 1 ]; then
-                        echo "Not an integer greater than zero...exiting." && exit 1
-                fi
-	     ;;
-     esac
-done
 
 # add parameters to $SO_CONF if they don't already exist
 grep DAYSTOKEEP $SO_CONF >/dev/null	|| echo "DAYSTOKEEP=365"	>> $SO_CONF
@@ -99,8 +69,37 @@ if ! grep UNCAT_MAX $SO_CONF >/dev/null; then
 	echo "UNCAT_MAX=100000"	>> $SO_CONF
 fi
 
-#  If we are not using an option, read in the user's custom settings from $SO_CONF.
-[[ $OPT -ne 1 ]] && source $SO_CONF
+#  Read in the user's custom settings from $SO_CONF.
+source $SO_CONF
+
+# If user specifies an option, we will replace the values from $SO_CONF with the user-specified value(s).
+while getopts "k:r:u:h" OPTION
+do
+     case $OPTION in
+         h)
+                usage
+                exit 0
+             ;;
+         k)
+                DAYSTOKEEP=$OPTARG
+                if ! [ $DAYSTOKEEP -ge 1 ]; then
+                        echo "Not an integer greater than zero...exiting." && exit 1
+                fi
+             ;;
+         r)
+                DAYSTOREPAIR=$OPTARG
+                if ! [ $DAYSTOREPAIR -ge 1 ]; then
+                        echo "Not an integer greater than zero...exiting." && exit 1
+                fi
+             ;;
+         u)
+                UNCAT_MAX=$OPTARG
+                if ! [ $UNCAT_MAX -ge 1 ]; then
+                        echo "Not an integer greater than zero...exiting." && exit 1
+                fi
+             ;;
+     esac
+done
 
 # Check to see if there is a valid DB.  If not, exit silently.
 if [ ! -d /var/lib/mysql/$DATABASE/ ]; then exit; fi

--- a/bin/sguil-db-purge
+++ b/bin/sguil-db-purge
@@ -65,46 +65,25 @@ do
 		exit 0
 	     ;;
 	 k)
+		OPT=1
 		DAYSTOKEEP=$OPTARG
 		if ! [ $DAYSTOKEEP -ge 1 ]; then
                         echo "Not an integer greater than zero...exiting." && exit 1
                 fi
-		if ! grep DAYSTOKEEP $SO_CONF >/dev/null; then
-			#DAYSTOKEEP=$OPTARG
-			echo "DAYSTOKEEP=$DAYSTOKEEP" >> $SO_CONF
-		else
-			#DAYSTOKEEP=$OPTARG
-			sed -i "s|DAYSTOKEEP.*|DAYSTOKEEP=$DAYSTOKEEP|g" $SO_CONF
-		fi
 	     ;;
 	 r)
+		OPT=1
 		DAYSTOREPAIR=$OPTARG
 		if ! [ $DAYSTOREPAIR -ge 1 ]; then
 			echo "Not an integer greater than zero...exiting." && exit 1
 		fi
-		if ! grep DAYSTOREPAIR $SO_CONF >/dev/null; then
-                        #DAYSTOREPAIR=$OPTARG
-                        echo "DAYSTOREPAIR=$DAYSTOREPAIR" >> $SO_CONF
-                else
-                        #DAYSTOREPAIR=$OPTARG
-                        sed -i "s|DAYSTOREPAIR.*|DAYSTOREPAIR=$DAYSTOREPAIR|g" $SO_CONF
-                fi
 	     ;;
 	 u)
+		OPT=1
 		UNCAT_MAX=$OPTARG
 		if ! [ $UNCAT_MAX -ge 1 ]; then
                         echo "Not an integer greater than zero...exiting." && exit 1
                 fi
-		if ! grep UNCAT_MAX $SO_CONF >/dev/null; then
-			#UNCAT_MAX=$OPTARG
-			echo >> $SO_CONF
-			echo "# What is the maximum number of uncategorized events to allow?" >> $SO_CONF
-			echo "# If this number gets too high, then sguild startup may be delayed." >> $SO_CONF
-			echo "UNCAT_MAX=$UNCAT_MAX" >> $SO_CONF
-		else
-			#UNCAT_MAX=$OPTARG
-			sed -i "s|UNCAT_MAX.*|UNCAT_MAX=$UNCAT_MAX|g" $SO_CONF
-		fi
 	     ;;
      esac
 done
@@ -120,8 +99,8 @@ if ! grep UNCAT_MAX $SO_CONF >/dev/null; then
 	echo "UNCAT_MAX=100000"	>> $SO_CONF
 fi
 
-# Read in the user's custom settings from $SO_CONF
-source $SO_CONF
+#  If we are not using an option, read in the user's custom settings from $SO_CONF.
+[[ $OPT -ne 1 ]] && source $SO_CONF
 
 # Check to see if there is a valid DB.  If not, exit silently.
 if [ ! -d /var/lib/mysql/$DATABASE/ ]; then exit; fi

--- a/bin/sguil-db-purge
+++ b/bin/sguil-db-purge
@@ -67,7 +67,7 @@ do
 	 k)
 		DAYSTOKEEP=$OPTARG
 		if ! [ $DAYSTOKEEP -ge 1 ]; then
-                        echo "Not an integer greater than zero...exiting." && exit 0
+                        echo "Not an integer greater than zero...exiting." && exit 1
                 fi
 		if ! grep DAYSTOKEEP $SO_CONF >/dev/null; then
 			#DAYSTOKEEP=$OPTARG
@@ -80,7 +80,7 @@ do
 	 r)
 		DAYSTOREPAIR=$OPTARG
 		if ! [ $DAYSTOREPAIR -ge 1 ]; then
-			echo "Not an integer greater than zero...exiting." && exit 0
+			echo "Not an integer greater than zero...exiting." && exit 1
 		fi
 		if ! grep DAYSTOREPAIR $SO_CONF >/dev/null; then
                         #DAYSTOREPAIR=$OPTARG
@@ -93,7 +93,7 @@ do
 	 u)
 		UNCAT_MAX=$OPTARG
 		if ! [ $UNCAT_MAX -ge 1 ]; then
-                        echo "Not an integer greater than zero...exiting." && exit 0
+                        echo "Not an integer greater than zero...exiting." && exit 1
                 fi
 		if ! grep UNCAT_MAX $SO_CONF >/dev/null; then
 			#UNCAT_MAX=$OPTARG

--- a/bin/sguil-db-purge
+++ b/bin/sguil-db-purge
@@ -40,6 +40,75 @@ UNCAT_MAX=100000
 # check for variables in /etc/nsm/securityonion.conf
 SO_CONF="/etc/nsm/securityonion.conf"
 
+# Options
+usage()
+{
+cat <<EOF
+
+Security Onion: Database Event Purge Script
+
+     Options:
+
+	-h		This message
+        -k              Number of days to keep in Sguil database
+        -r              Days worth of Sguil's event tables to repair
+        -u              Maximum number of uncategorized events
+
+Usage: $0
+EOF
+}
+while getopts "k:r:u:h" OPTION
+do
+     case $OPTION in
+	 h)
+		usage
+		exit 0
+	     ;;
+	 k)
+		DAYSTOKEEP=$OPTARG
+		if ! [ $DAYSTOKEEP -ge 1 ]; then
+                        echo "Not an integer greater than zero...exiting." && exit 0
+                fi
+		if ! grep DAYSTOKEEP $SO_CONF >/dev/null; then
+			#DAYSTOKEEP=$OPTARG
+			echo "DAYSTOKEEP=$DAYSTOKEEP" >> $SO_CONF
+		else
+			#DAYSTOKEEP=$OPTARG
+			sed -i "s|DAYSTOKEEP.*|DAYSTOKEEP=$DAYSTOKEEP|g" $SO_CONF
+		fi
+	     ;;
+	 r)
+		DAYSTOREPAIR=$OPTARG
+		if ! [ $DAYSTOREPAIR -ge 1 ]; then
+			echo "Not an integer greater than zero...exiting." && exit 0
+		fi
+		if ! grep DAYSTOREPAIR $SO_CONF >/dev/null; then
+                        #DAYSTOREPAIR=$OPTARG
+                        echo "DAYSTOREPAIR=$DAYSTOREPAIR" >> $SO_CONF
+                else
+                        #DAYSTOREPAIR=$OPTARG
+                        sed -i "s|DAYSTOREPAIR.*|DAYSTOREPAIR=$DAYSTOREPAIR|g" $SO_CONF
+                fi
+	     ;;
+	 u)
+		UNCAT_MAX=$OPTARG
+		if ! [ $UNCAT_MAX -ge 1 ]; then
+                        echo "Not an integer greater than zero...exiting." && exit 0
+                fi
+		if ! grep UNCAT_MAX $SO_CONF >/dev/null; then
+			#UNCAT_MAX=$OPTARG
+			echo >> $SO_CONF
+			echo "# What is the maximum number of uncategorized events to allow?" >> $SO_CONF
+			echo "# If this number gets too high, then sguild startup may be delayed." >> $SO_CONF
+			echo "UNCAT_MAX=$UNCAT_MAX" >> $SO_CONF
+		else
+			#UNCAT_MAX=$OPTARG
+			sed -i "s|UNCAT_MAX.*|UNCAT_MAX=$UNCAT_MAX|g" $SO_CONF
+		fi
+	     ;;
+     esac
+done
+
 # add parameters to $SO_CONF if they don't already exist
 grep DAYSTOKEEP $SO_CONF >/dev/null	|| echo "DAYSTOKEEP=365"	>> $SO_CONF
 grep DAYSTOREPAIR $SO_CONF >/dev/null	|| echo "DAYSTOREPAIR=365"	>> $SO_CONF


### PR DESCRIPTION
This prevents having to modify /etc/nsm/securityonion.conf before running sguil-db-purge (if changing to a value other than what is defined in the initially configured file).  The option(s) will write a new value to the file (the value specified as an argument to the command line option).

Options are as follows (differing slightly from the actual text in the pull request):

-h               Help message
-k               Days to keep
-r                Days to repair
-u              Uncat_max

Ex. sudo sguil-db-purge -k 5 -r 5 -u 1000

...would set the DAYSTOKEEP variable as 5, the DAYSTOREPAIR variable as 5, and UNCAT_MAX as 1000.

While I realize, this doesn't save a **ton** of work, I imagine it could be beneficial to some folks.

Thanks,
Wes
